### PR TITLE
Update const.py

### DIFF
--- a/smart_meter_texas/const.py
+++ b/smart_meter_texas/const.py
@@ -1,6 +1,6 @@
 import datetime
 
-BASE_HOSTNAME = "www.smartmetertexas.com"
+BASE_HOSTNAME = "smartmetertexas.com"
 BASE_URL = "https://" + BASE_HOSTNAME + "/"
 BASE_ENDPOINT = BASE_URL + "api"
 AUTH_ENDPOINT = "/user/authenticate"


### PR DESCRIPTION
Changes the base hostname to just smartmetertexas.com

The base domain is now part of the SSL certificate's SAN:  https://github.com/home-assistant/core/issues/57582#issuecomment-1287929568

This change should help resolve the issue here: https://github.com/home-assistant/core/issues/57582