### PR TITLE
Daily Readings

### DIFF
--- a/smart_meter_texas/__init__.py
+++ b/smart_meter_texas/__init__.py
@@ -11,6 +11,7 @@ from random import randrange
 import asn1
 import certifi
 import dateutil.parser
+from dateutil.tz import gettz
 import OpenSSL.crypto as crypto
 from aiohttp import ClientSession
 from tenacity import retry, retry_if_exception_type
@@ -28,6 +29,7 @@ from .const import (
     OD_READ_RETRY_TIME,
     TOKEN_EXPRIATION,
     USER_AGENT_TEMPLATE,
+    READING_DAILY,
 )
 from .exceptions import (
     SmartMeterTexasAPIDateError,
@@ -50,6 +52,7 @@ class Meter:
         self.esiid = esiid
         self.address = address
         self.reading_data = None
+        self.daily_reading = None
         self.interval = None
 
     async def read_meter(self, client: Client):
@@ -88,6 +91,49 @@ class Meter:
                 else:
                     _LOGGER.error("Unknown meter reading status: %s", status)
                     raise SmartMeterTexasAPIError(f"Unknown meter status: {status}")
+
+    async def get_daily(self, client: Client, ts=None):
+        """Get the daily reading of the meter"""
+
+        # Default to yesterday. Daily reading for "today" won't be available until tomorrow
+        if ts is None:
+            ts = datetime.date.today() - datetime.timedelta(days=1)
+
+        # {"esiid":"NNNNNNNNNNNNNNNNN","startDate":"07/19/2023","endDate":"07/19/2023"}
+        payload = {
+            "esiid": self.esiid,
+            "startDate": ts.strftime("%m/%d/%Y"),
+            "endDate": ts.strftime("%m/%d/%Y"),
+        }
+
+        _LOGGER.debug(f"Getting daily reading for '{ts}' using {payload}")
+        json_response = await client.request(
+            READING_DAILY,
+            json=payload,
+        )
+
+        try:
+            _LOGGER.debug(f"Daily reading data {json_response}")
+            data = json_response["dailyData"]
+            if len(data) != 1:
+                raise SmartMeterTexasAPIError("Too many data points returned")
+            data = data[0]
+        except KeyError:
+            msg = f"Error reading daily data: {json_response}"
+            _LOGGER.error(msg)
+            raise SmartMeterTexasAPIError(msg)
+        else:
+
+            dt = dateutil.parser.parse(f"{data['date']} {data['starttime']}").replace(tzinfo=gettz("America/Chicago"))
+            self.daily_reading = {
+                "timestamp": dt,
+                "startreading": float(data["startreading"]),
+                "endreading": float(data["endreading"]),
+                "usage": float(data["reading"]),
+            }
+
+            return self.daily_reading
+
 
     async def get_15min(self, client: Client, prevdays=1):
         """Get the interval data to parse out Surplus Generation"""
@@ -179,6 +225,11 @@ class Meter:
     def read_15min(self):
         """Returns the list of date/times and the consumption rate"""
         return self.interval
+
+    @property
+    def read_daily(self):
+        """Returns the dictionary of the most recent daily reading as provided by SMT"""
+        return self.daily_reading
 
 
 class Account:

--- a/smart_meter_texas/__init__.py
+++ b/smart_meter_texas/__init__.py
@@ -95,7 +95,7 @@ class Meter:
     async def get_daily(self, client: Client, ts=None):
         """Get the daily reading of the meter"""
 
-        # Default to yesterday. Daily reading for "today" won't be available until tomorrow
+        # Default to yesterday. Daily reading for "today" usually is not available until "tomorrow"
         if ts is None:
             ts = datetime.date.today() - datetime.timedelta(days=1)
 
@@ -116,7 +116,9 @@ class Meter:
             _LOGGER.debug(f"Daily reading data {json_response}")
             data = json_response["dailyData"]
             if len(data) == 0:
-                raise SmartMeterTexasAPIError("No data points returned.")
+                # Return a DateError to differentiate between too much data so user
+                # can decide to modify the date object and retry
+                raise SmartMeterTexasAPIDateError("No data points returned.")
             elif len(data) > 1:
                 raise SmartMeterTexasAPIError("Too many data points returned")
             else:

--- a/smart_meter_texas/const.py
+++ b/smart_meter_texas/const.py
@@ -9,6 +9,7 @@ LATEST_OD_READ_ENDPOINT = "/usage/latestodrread"
 METER_ENDPOINT = "/meter"
 OD_READ_ENDPOINT = "/ondemandread"
 INTERVAL_SYNCH = "/adhoc/intervalsynch"
+READING_DAILY = "/usage/daily"
 
 USER_AGENT_TEMPLATE = (
     "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_6) "


### PR DESCRIPTION
This PR implements the API endpoint /api/usage/daily to fetch the most recent daily meter reading, which usually occurs at midnight of the previous day.

I've got another PR I'm working on that correctly parses 15min data. Unfortunately, the data provided by SMT does not contain the actual meter readings, it contains deltas.

Using this PR to fetch the previous days' midnight meter reading, and using a proper 15min data delta set, you can calculate the meter values every 15m, which is more desirable when storing into a time series database like influx, for presentations into grafana.