### PR TITLE
Support 15min data for Surplus and Consume

### DIFF
--- a/smart_meter_texas/__init__.py
+++ b/smart_meter_texas/__init__.py
@@ -163,7 +163,7 @@ class Meter:
                             elif minute_check % 4 == 3:
                                 minute = 45
                             minute_check += 1
-                            num = generated.split("-")[0]
+                            num = float(generated.split("-")[0])
 
                             ref.append(
                                 [

--- a/smart_meter_texas/__init__.py
+++ b/smart_meter_texas/__init__.py
@@ -125,7 +125,9 @@ class Meter:
                     tdsp = "TDSP" in data["errorMessage"]
                     if tdsp:
                         retry += 1
-                        yesterday = datetime.date.today() - datetime.timedelta(days=retry)
+                        yesterday = datetime.date.today() - datetime.timedelta(
+                            days=retry
+                        )
                         if retry < 3:
                             continue
                         else:
@@ -140,8 +142,8 @@ class Meter:
                 hour = -1
                 minute_check = 0
                 for entry in energy:
-                    """ energy[] may contain 1 or 2 arrays containing 'C' consumed energy,
-                        or 'G' surplus energy generated """
+                    """energy[] may contain 1 or 2 arrays containing 'C' consumed energy,
+                    or 'G' surplus energy generated"""
 
                     if entry["RT"] == "G":
                         ref = surplus
@@ -163,10 +165,14 @@ class Meter:
                             minute_check += 1
                             num = generated.split("-")[0]
 
-                            ref.append([
-                                datetime.datetime.combine(yesterday, datetime.time(hour, minute, 0)),
-                                num
-                            ])
+                            ref.append(
+                                [
+                                    datetime.datetime.combine(
+                                        yesterday, datetime.time(hour, minute, 0)
+                                    ),
+                                    num,
+                                ]
+                            )
 
                 self.interval = {"consumed": consumed, "surplus": surplus}
                 return self.interval

--- a/smart_meter_texas/__init__.py
+++ b/smart_meter_texas/__init__.py
@@ -50,7 +50,7 @@ class Meter:
         self.esiid = esiid
         self.address = address
         self.reading_data = None
-        self.interval = None
+        self.interval = {"consumed": None, "surplus": None}
 
     async def read_meter(self, client: Client):
         """Triggers an on-demand meter read and returns it when complete."""
@@ -90,26 +90,21 @@ class Meter:
                     raise SmartMeterTexasAPIError(f"Unknown meter status: {status}")
 
     async def get_15min(self, client: Client, prevdays=1):
-        """Get the interval data to parse out Surplus Generation"""
+        """Get the interval data to parse out consumed, and surplus generation"""
         retry = 1
         prevdays = int(prevdays)
-        if prevdays == 1:
-            yesterday = (datetime.date.today() - datetime.timedelta(days=1)).strftime(
-                "%m/%d/%Y"
-            )
-        else:
-            yesterday = (
-                datetime.date.today() - datetime.timedelta(days=prevdays)
-            ).strftime("%m/%d/%Y")
+        yesterday = datetime.date.today() - datetime.timedelta(days=prevdays)
+
         while retry < 3:
-            _LOGGER.debug("Getting Interval data")
+            _LOGGER.debug(f"Getting interval data for {yesterday}")
             surplus = []
+            consumed = []
 
             json_response = await client.request(
                 INTERVAL_SYNCH,
                 json={
-                    "startDate": yesterday,
-                    "endDate": yesterday,
+                    "startDate": yesterday.strftime("%m/%d/%Y"),
+                    "endDate": yesterday.strftime("%m/%d/%Y"),
                     "reportFormat": "JSON",
                     "ESIID": [self.esiid],
                     "versionDate": None,
@@ -118,18 +113,18 @@ class Meter:
                     "dataType": None,
                 },
             )
+
             try:
                 data = json_response["data"]
                 energy = data["energyData"]
+
             except KeyError:
-                _LOGGER.error("Error reading data: ", json_response)
+                _LOGGER.error(f"Error reading data: {json_response}")
                 if data["errorCode"] == "1":
                     tdsp = "TDSP" in data["errorMessage"]
                     if tdsp:
                         retry += 1
-                        yesterday = (
-                            datetime.date.today() - datetime.timedelta(days=retry)
-                        ).strftime("%m/%d/%Y")
+                        yesterday = datetime.date.today() - datetime.timedelta(days=retry)
                         if retry < 3:
                             continue
                         else:
@@ -144,24 +139,36 @@ class Meter:
                 hour = -1
                 minute_check = 0
                 for entry in energy:
+                    """ energy[] may contain 1 or 2 arrays containing 'C' consumed energy,
+                        or 'G' surplus energy generated """
+
                     if entry["RT"] == "G":
-                        readdata = entry["RD"].split(",")
-                        for generated in readdata:
-                            if generated != "":
-                                if minute_check % 4 == 0:
-                                    hour += 1
-                                    minute = "00"
-                                elif minute_check % 4 == 1:
-                                    minute = "15"
-                                elif minute_check % 4 == 2:
-                                    minute = 30
-                                elif minute_check % 4 == 3:
-                                    minute = 45
-                                minute_check += 1
-                                num = generated.split("-")[0]
-                                surplus.append([f"{yesterday} {hour}:{minute}", num])
-                                self.interval = surplus
-                        return self.interval
+                        ref = surplus
+                    else:
+                        ref = consumed
+
+                    readdata = entry["RD"].split(",")
+                    for generated in readdata:
+                        if generated != "":
+                            if minute_check % 4 == 0:
+                                hour += 1
+                                minute = 0
+                            elif minute_check % 4 == 1:
+                                minute = 15
+                            elif minute_check % 4 == 2:
+                                minute = 30
+                            elif minute_check % 4 == 3:
+                                minute = 45
+                            minute_check += 1
+                            num = generated.split("-")[0]
+
+                            ref.append([
+                                datetime.datetime.combine(yesterday, datetime.time(hour, minute, 0)),
+                                num
+                            ])
+
+                self.interval = {"consumed": consumed, "surplus": surplus}
+                return self.interval
 
     @property
     def reading(self):


### PR DESCRIPTION
The current implementation of get15min only collects surplus generation. I would hazard a guess that _most_ people don't generate surplus energy, and that most people are instead consumers.

This breaking change PR changes the returned object of get_15min from a simple `[]` array containing surplus data, to a dict `{}` containing two keys: `surplus` and `consumed` in which the values of each are arrays containing a datetime object and the surplus or consumed value.

Additionally, this PR modifies the `yesterday` datetime object to use more native features and only output a string for the API call.