### PR TITLE
Resolves #148 and Add a Timeout for Reading the Meter

### DIFF
--- a/smart_meter_texas/__init__.py
+++ b/smart_meter_texas/__init__.py
@@ -62,6 +62,7 @@ class Meter:
             OD_READ_ENDPOINT,
             json={"ESIID": self.esiid, "MeterNumber": self.meter},
         )
+        await asyncio.sleep(OD_READ_RETRY_TIME)
 
         # Occasionally check to see if on-demand meter reading is complete.
         while True:

--- a/smart_meter_texas/__init__.py
+++ b/smart_meter_texas/__init__.py
@@ -26,6 +26,7 @@ from .const import (
     LATEST_OD_READ_ENDPOINT,
     METER_ENDPOINT,
     OD_READ_ENDPOINT,
+    OD_READ_RETRIES,
     OD_READ_RETRY_TIME,
     TOKEN_EXPRIATION,
     USER_AGENT_TEMPLATE,
@@ -64,12 +65,16 @@ class Meter:
         )
         await asyncio.sleep(OD_READ_RETRY_TIME)
 
+        trys = 0
         # Occasionally check to see if on-demand meter reading is complete.
         while True:
+            if trys >= OD_READ_RETRIES:
+                raise SmartMeterTexasAPIError("Exceeded retries for meter reading")
             json_response = await client.request(
                 LATEST_OD_READ_ENDPOINT,
                 json={"ESIID": self.esiid},
             )
+            trys += 1
             try:
                 data = json_response["data"]
                 status = data["odrstatus"]

--- a/smart_meter_texas/const.py
+++ b/smart_meter_texas/const.py
@@ -35,4 +35,5 @@ API_ERROR_RESPONSES = {
 API_DATE_ERROR = "No Energy Data received from the respective TDSP"
 
 OD_READ_RETRY_TIME = 15
+OD_READ_RETRIES = 160
 TOKEN_EXPRIATION = datetime.timedelta(minutes=15)


### PR DESCRIPTION
I've locally tested adding another sleep between when the ODR is requested and when requests are made to `/latestodread`. This appears to fix #148, I assume that `/ondemandread` doesn't have enough time to update the resource behind `/latestodread` when the calls are made immediately after one another, causing unexpected behavior in some cases.